### PR TITLE
chore: optimize config, package.json, html

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ This template includes:
 
 ## Commands
 
-* `npm run serve-dev` serves a non-optimized dev version using webpack dev server
-* `npm run serve-prod` serves an optimized production version using webpack dev server
-* `npm run build-dev` just builds the non-optimized version
-* `npm run build-prod` just builds an optimized production version
+* `npm start` serves a non-optimized dev version using webpack dev server
+* `npm run start:prod` serves an optimized production version using webpack dev server
+* `npm run build` just builds an optimized production version
+* `npm run build:dev` just builds the non-optimized version
 * `npm run deploy` runs a gulp script that builds an optimized production version and gzips .js and .css assets. You are meant to extend the gulp script to do other deploy things like upload to AWS or the like.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "cssnano": "6.0.1",
                 "gulp": "4.0.2",
                 "gulp-gzip": "1.4.2",
-                "html-bundler-webpack-plugin": "1.18.0",
+                "html-bundler-webpack-plugin": "2.2.3",
                 "lazysizes": "5.3.2",
                 "postcss": "8.4.24",
                 "postcss-loader": "7.3.2",
@@ -2507,9 +2507,9 @@
             }
         },
         "node_modules/eta": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/eta/-/eta-2.2.0.tgz",
-            "integrity": "sha512-UVQ72Rqjy/ZKQalzV5dCCJP80GrmPrMxh6NlNf+erV6ObL0ZFkhCstWRawS85z3smdr3d2wXPsZEY7rDPfGd2g==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/eta/-/eta-3.0.3.tgz",
+            "integrity": "sha512-92A9Ag87aSb/y7e9EwA17VsbV1t2NmZNVlxtwHIkQcxYq20Ch7aAVNJqb5w6bsJVXRsBdvzn6R8WDPCHI9ewdA==",
             "dev": true,
             "engines": {
                 "node": ">=6.0.0"
@@ -4135,14 +4135,14 @@
             }
         },
         "node_modules/html-bundler-webpack-plugin": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/html-bundler-webpack-plugin/-/html-bundler-webpack-plugin-1.18.0.tgz",
-            "integrity": "sha512-CLIs9KvkYAiBa4yJe36Imi4xk6wVRtWtANOWdxBQ5xEBVmoPYDzVUoNulzQaAVD2cgHVKzdwrJ7RVSmZ5WXuRw==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/html-bundler-webpack-plugin/-/html-bundler-webpack-plugin-2.2.3.tgz",
+            "integrity": "sha512-+FshX7CNzfP8KGSvq2/EvrixXpBODEgmygNSxu0n/hOBfQIQz+zgZXG2gpPJqkCsR9L5TANu7zU1EZN+5bZFKg==",
             "dev": true,
             "dependencies": {
                 "ansis": "1.5.5",
                 "enhanced-resolve": ">=5.7.0",
-                "eta": "^2.0.1",
+                "eta": "^3.0.3",
                 "html-minifier-terser": "^7.2.0",
                 "json5": "^2.2.3"
             },

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
     "name": "frontend-template",
     "type": "module",
     "scripts": {
-        "serve-dev": "webpack serve --config webpack.dev.js",
-        "serve-prod": "webpack serve --open --config webpack.prod.js",
-        "build-dev": "webpack --config webpack.dev.js",
-        "build-prod": "webpack --config webpack.prod.js",
+        "start": "webpack serve --config webpack.dev.js",
+        "start:prod": "webpack serve --open --config webpack.prod.js",
+        "build": "webpack --config webpack.prod.js",
+        "build:dev": "webpack --config webpack.dev.js",
         "deploy": "gulp deploy"
     },
     "devDependencies": {
@@ -19,7 +19,7 @@
         "cssnano": "6.0.1",
         "gulp": "4.0.2",
         "gulp-gzip": "1.4.2",
-        "html-bundler-webpack-plugin": "1.18.0",
+        "html-bundler-webpack-plugin": "2.2.3",
         "lazysizes": "5.3.2",
         "postcss": "8.4.24",
         "postcss-loader": "7.3.2",

--- a/src/index.html
+++ b/src/index.html
@@ -6,9 +6,8 @@
     <link href="styles/index.scss" rel="stylesheet">
 </head>
 <body>
-<div id="root"></div>
-<div>
-</div>
+    <div id="root"></div>
+    <div></div>
+    <script src="scripts/App.tsx" defer="defer"></script>
 </body>
-<script src="scripts/App.tsx" defer="defer"></script>
 </html>

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -30,7 +30,6 @@ export default {
     entry: {},
     output: {
         path: path.resolve(__dirname, 'dist'),
-        filename: '[name].[contenthash].js',
         clean: true
     },
     module: {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -30,7 +30,6 @@ export default {
     entry: {},
     output: {
         path: path.resolve(__dirname, 'dist'),
-        filename: '[name].[contenthash].js',
         clean: true
     },
     module: {


### PR DESCRIPTION
Hello @rageix,

thanks for the react boilerplate.

I have minor corrections.

## Standard script names used in package.json
- `start` instead of `serve-dev`. You can run the scripts with short `npm start`. This is standard. Defaults, `start` must be run in `development` mode.
- `start:prod` - non-standard variant of `start` script. Any variant of standard name should be have a suffix, e.g. `:prod`, `:dev`, etc.
- `build` instead of `build-prod`. This is standard. Defaults, `build` must be run in `production` mode.
- `build:dev` - non-standard variant of `build` script.


## The place of script tag in HTML

By W3C convention, the `script` tag must be in `head` or in `body`, before close body tag, nu not after. 
It is very important, otherwise the browser generate additional process to remove the script tag in body. See in the browser inspector, scripts are always before `</body>`.

```html
<body>
    <!-- place script here, before close body tag -->
    <script src="..."></script>
</body>
```

## Webpack config

Using the HTML bundler plugin, the real output filename of JS files is the `js.filename` plugin option, the webpack `output.filename` is not used.